### PR TITLE
allow dots as part of table name

### DIFF
--- a/src/main/java/ru/yandex/money/common/dbqueue/settings/QueueLocation.java
+++ b/src/main/java/ru/yandex/money/common/dbqueue/settings/QueueLocation.java
@@ -15,7 +15,7 @@ public final class QueueLocation {
     /**
      * Regexp for SQL injection prevention
      */
-    private static final Pattern DISALLOWED_CHARS = Pattern.compile("[^a-zA-Z0-9_]*");
+    private static final Pattern DISALLOWED_CHARS = Pattern.compile("[^a-zA-Z0-9_\\.]*");
 
     @Nonnull
     private final String tableName;

--- a/src/test/java/ru/yandex/money/common/dbqueue/settings/QueueLocationTest.java
+++ b/src/test/java/ru/yandex/money/common/dbqueue/settings/QueueLocationTest.java
@@ -20,7 +20,7 @@ public class QueueLocationTest {
     @Test
     public void should_filter_special_chars() {
         Assert.assertThat(QueueLocation.builder().withQueueId(new QueueId("1"))
-                .withTableName(" l !@#$%^&*()_+-=1\n;'][{}").build().getTableName(), equalTo("l_1"));
+                .withTableName(" l !@#$%^&*()._+-=1\n;'][{}").build().getTableName(), equalTo("l._1"));
     }
 
 }


### PR DESCRIPTION
This is specially useful when combined with schemas in postgres. For
example, in a multi-tenant environment, a schema could be used per
tenant to ensure data separation between tenants. However, enqueue would
happen into a shared table in a shared schema. This way, tenants share
the infrastructure (in this case workers instead of one worker process
per tenant) but still have their own data island.

P.S. this is the only part that prevented us from having a smooth upgrade to v8.0.0.